### PR TITLE
Add an option to specify a CredSpec file for gMSA accounts

### DIFF
--- a/src/buildbot_docker_swarm_worker/_plugin.py
+++ b/src/buildbot_docker_swarm_worker/_plugin.py
@@ -25,7 +25,7 @@ class DockerSwarmLatentWorker(AbstractLatentWorker):
 
     """
 
-    def __init__(self, name, image, credspec_file):
+    def __init__(self, name, image, credspec_file=None):
         password = secrets.token_hex(16)
 
         super().__init__(name, password, build_wait_timeout=0)

--- a/src/buildbot_docker_swarm_worker/_plugin.py
+++ b/src/buildbot_docker_swarm_worker/_plugin.py
@@ -25,7 +25,7 @@ class DockerSwarmLatentWorker(AbstractLatentWorker):
 
     """
 
-    def __init__(self, name, image):
+    def __init__(self, name, image, credspec_file):
         password = secrets.token_hex(16)
 
         super().__init__(name, password, build_wait_timeout=0)
@@ -56,6 +56,7 @@ class DockerSwarmLatentWorker(AbstractLatentWorker):
         self.service = None
         self.service_config = {
             "image": image,
+            "privileges": Privileges(credentialspec_file = credspec_file),
             "init": True,
             "networks": get_container_networks(),
             "restart_policy": docker.types.RestartPolicy(condition="none"),


### PR DESCRIPTION
New option to specify a credential spec file[1] to run Swarm-based workers with gMSA account[2] (required to enable authentication within Active Directory domain). The change lets you specify filename, but doesn't yet work with CredSpec file supplied via Swarm config.

Example (the third option with the *.json file):

```
c['workers'] = [
    	worker.DockerSwarmLatentWorker(
     	"docker-swarm-worker-foo",
     	"workerimage-foo:latest",
     	"fooworker.json"),
    	worker.DockerSwarmLatentWorker(
     	"docker-swarm-worker-bar",
     	"workerimage-bar:latest",
     	"barworker.json")

```

[1]: https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/manage-serviceaccounts
[2]: https://docs.docker.com/engine/swarm/services/#gmsa-for-swarm